### PR TITLE
0.2.0: Generative testing now works for `defns`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/clojure:lein-2.7.1
+    working_directory: ~/repo
+    environment:
+      LEIN_ROOT: "true"
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "project.clj" }}
+          # Fall back to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: lein deps
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+      - run: lein with-profile clj-1.8 test && lein with-profile clj-1.9 test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.DS_Store

--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,31 @@
-(defproject quantum/defnt "0.0.1"
+(def deps|clj-1-8
+ '[[clojure-future-spec    "1.9.0-beta4"]
+   [frankiesardo/linked    "1.2.9"]
+   [org.clojure/clojure    "1.8.0"]])
+
+(def deps|clj-1-9
+ '[[clojure-future-spec    "1.9.0-beta4"]
+   [frankiesardo/linked    "1.2.9"]
+   [org.clojure/clojure    "1.9.0"]
+   [org.clojure/spec.alpha "0.1.143"]])
+
+(defproject quantum/defnt "0.2.0"
   :description  "Where `defn` meets `clojure.spec` and a gradual-typing baby is born."
   :url          "https://github.com/alexandergunnarson/defnt"
   :license      {:name         "Creative Commons Attribution-ShareAlike 3.0 US (CC-SA)"
                  :url          "https://creativecommons.org/licenses/by-sa/3.0/us/"
                  :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.8.0"] ; or 1.9.0
-                 [clojure-future-spec "1.9.0-beta4"]
-                 [frankiesardo/linked "1.2.9"]]
   :profiles
-    {:dev {:global-vars  {*warn-on-reflection* true
-                          *unchecked-math*     :warn-on-boxed}
-           :dependencies [[org.clojure/clojure    "1.9.0"]
-                          [expound                "0.6.0"]
-                          [orchestra              "2017.11.12-1"]
-                          [org.clojure/spec.alpha "0.1.143"]
-                          [org.clojure/test.check "0.9.0"]]}})
+    {:dev||test {:global-vars {*warn-on-reflection* true
+                               *unchecked-math*     :warn-on-boxed}}
+     :dev       [:dev||test
+                 {:dependencies ~(conj deps|clj-1-9
+                                   '[expound                "0.6.0"]
+                                   '[orchestra              "2017.11.12-1"]
+                                   '[org.clojure/test.check "0.9.0"])}]
+     :test      [:dev||test]
+     :clj-1-8   {:dependencies ~(conj deps|clj-1-8
+                                  '[org.clojure/test.check "0.9.0"])}
+     :clj-1-9   {:dependencies ~(conj deps|clj-1-9
+                                  '[org.clojure/test.check "0.9.0"])}})
 

--- a/src/quantum/untyped/core/defnt.cljc
+++ b/src/quantum/untyped/core/defnt.cljc
@@ -130,7 +130,7 @@
            (s/cat
              :quantum.core.specs/fn|name   (s/? :quantum.core.specs/fn|name)
              :quantum.core.specs/docstring (s/? :quantum.core.specs/docstring)
-             :quantum.core.specs/meta      (s/? :quantum.core.specs/meta)
+             :pre-meta                     (s/? :quantum.core.specs/meta)
              :output-spec                  :quantum.core.defnt/output-spec
              :overloads                    :quantum.core.defnt/overloads))
          :quantum.core.specs/fn|postchecks
@@ -143,7 +143,7 @@
            (s/cat
              :quantum.core.specs/fn|name   :quantum.core.specs/fn|name
              :quantum.core.specs/docstring (s/? :quantum.core.specs/docstring)
-             :quantum.core.specs/meta      (s/? :quantum.core.specs/meta)
+             :pre-meta                     (s/? :quantum.core.specs/meta)
              :output-spec                  :quantum.core.defnt/output-spec
              :overloads                    :quantum.core.defnt/overloads))
          :quantum.core.specs/fn|postchecks

--- a/src/quantum/untyped/core/defnt.cljc
+++ b/src/quantum/untyped/core/defnt.cljc
@@ -263,7 +263,8 @@
                    ~@(when varargs [(:k varargs) `(s/* any?)]))
           kv-spec#
             (us/kv ~(cond-> (->> args (map (fn [{:keys [k spec]}] [k spec])) (into (om)))
-                      varargs (assoc (:k varargs) `(s/spec (s/& (s/* any?) ~(:spec varargs))))))
+                      varargs (assoc (:k varargs)
+                                     `(s/spec (s/& (s/* any?) (s/conformer seq) ~(:spec varargs))))))
           conformer# (s/conformer (fn [x#] (s/unform destructurer# x#)))]
       (s/with-gen (s/and destructurer# kv-spec# conformer# ~seq-spec)
         (fn [] (->> (s/gen kv-spec#) (gen/fmap (fn [x#] (s/conform conformer# x#))))))))))

--- a/src/quantum/untyped/core/spec.cljc
+++ b/src/quantum/untyped/core/spec.cljc
@@ -1,17 +1,91 @@
 (ns quantum.untyped.core.spec
   (:require
+    [clojure.core           :as core]
     [clojure.spec.alpha     :as s]
     [clojure.spec.gen.alpha :as gen]))
 
+;; Implementation and interface modified from the Quantum original
 (defn validate [spec x]
   (let [conformed (s/conform spec x)]
     (if (s/invalid? conformed)
-        (let [ed (merge (assoc (s/explain-data* spec [] [] [] x)
-                          ::s/failure :assertion-failed))]
+        (let [ed (core/merge (assoc (s/explain-data* spec [] [] [] x)
+                               ::s/failure :assertion-failed))]
           (throw (ex-info
                    (str "Spec assertion failed\n" (with-out-str (s/explain-out ed)))
                    ed)))
         conformed)))
+
+(defn ^:internal kv-impl
+  "Based on `s/map-spec-impl`"
+  [k->s #_(s/map-of any? specable?) k->s|form #_(s/map-of any? any?) gen-fn #_(? fn?)]
+  (let [id (java.util.UUID/randomUUID)]
+    (reify
+      s/Specize
+        (specize* [this] this)
+        (specize* [this _] this)
+      s/Spec
+        (conform* [_ x]
+          (reduce
+            (fn [x' [k s]]
+              (let [v  (get x' k)
+                    cv (s/conform s v)]
+                (if (s/invalid? cv)
+                    ::s/invalid
+                    (if (identical? cv v)
+                        x'
+                        ;; TODO we might want to do `assoc?!`, depending
+                        (assoc x' k cv)))))
+            x
+            k->s))
+        (unform* [_ x]
+          (reduce
+            (fn [x' [k s]]
+              (let [cv (get x' k)
+                    v  (s/unform s cv)]
+                (if (identical? cv v)
+                    x'
+                    ;; TODO we might want to do `assoc?!`, depending
+                    (assoc x' k v))))
+            x
+            k->s))
+        (explain* [_ path via in x]
+          (if-not ;; TODO we might want a more generalized `map?` predicate like `t/map?`, depending,
+                  ;; which would affect more code below
+                  (map? x)
+            [{:path path :pred 'map? :val x :via via :in in}]
+            ;; TODO use reducers?
+            (->> x
+                 (map (fn [[k v]]
+                        (when-let [s (get k->s k)]
+                          (when-not (s/valid? s v)
+                            (cond->>
+                              (s/explain* s (conj path k) via (conj in k) v)
+                              (not (contains? x k))
+                              (cons {:path path :pred (list `contains? '% k) :val x :via via :in in}))))))
+                 (filter some?)
+                 (apply concat))))
+        (gen* [_ overrides path rmap]
+          (if gen-fn
+              (gen-fn)
+              (let [rmap (assoc rmap id (inc (core/or (get rmap id) 0)))
+                    gen  (fn [[k s]]
+                           (when-not (@#'s/recur-limit? rmap id path k)
+                             [k (gen/delay (@#'s/gensub s overrides (conj path k) rmap k))]))
+                    gens (->> k->s (map gen) (remove nil?) (into {}))]
+                (gen/bind (gen/choose 0 (count gens))
+                          (fn [n]
+                            (let [args (-> gens seq shuffle)]
+                              (->> args
+                                   (take n)
+                                   (apply concat)
+                                   (apply gen/hash-map))))))))
+        (with-gen* [_ gen-fn'] (kv-impl k->s k->s|form gen-fn'))
+        (describe* [_] `(kv ~k->s|form)))))
+
+#?(:clj
+(defmacro kv
+  "No `contains?` checks are performed."
+  [k->s] `(kv-impl ~(into {} k->s) '~k->s nil)))
 
 ;; NOTE: modified from the Quantum original
 #?(:clj (defmacro with [extract-f spec] `(s/nonconforming (s/and (s/conformer ~extract-f) ~spec))))

--- a/src/quantum/untyped/core/spec.cljc
+++ b/src/quantum/untyped/core/spec.cljc
@@ -54,14 +54,11 @@
                   (map? x)
             [{:path path :pred 'map? :val x :via via :in in}]
             ;; TODO use reducers?
-            (->> x
-                 (map (fn [[k v]]
-                        (when-let [s (get k->s k)]
+            (->> k->s
+                 (map (fn [[k s]]
+                        (let [v (get x k)]
                           (when-not (s/valid? s v)
-                            (cond->>
-                              (s/explain* s (conj path k) via (conj in k) v)
-                              (not (contains? x k))
-                              (cons {:path path :pred (list `contains? '% k) :val x :via via :in in}))))))
+                            (@#'s/explain-1 (get k->s|form k) s (conj path k) via (conj in k) v)))))
                  (filter some?)
                  (apply concat))))
         (gen* [_ overrides path rmap]

--- a/src/quantum/untyped/core/spec.cljc
+++ b/src/quantum/untyped/core/spec.cljc
@@ -87,7 +87,6 @@
           (with-gen* [_ gen-fn'] (kv k->s gen-fn'))
           (describe* [_] `(kv ~k->s|desc))))))
 
-;; NOTE: modified from the Quantum original
 (defn with-gen-spec-impl
   "Do not call this directly; use 'with-gen-spec'."
   [extract-f extract-f|form gen-spec gen-spec|form]
@@ -124,4 +123,3 @@
      {:a 1 :b 1})"
   [extract-f gen-spec]
   `(with-gen-spec-impl ~extract-f '~extract-f ~gen-spec '~gen-spec)))
-

--- a/src/quantum/untyped/core/spec.cljc
+++ b/src/quantum/untyped/core/spec.cljc
@@ -88,20 +88,19 @@
           (describe* [_] `(kv ~k->s|desc))))))
 
 ;; NOTE: modified from the Quantum original
-#?(:clj (defmacro with [extract-f spec] `(s/nonconforming (s/and (s/conformer ~extract-f) ~spec))))
-
-;; NOTE: modified from the Quantum original
 (defn with-gen-spec-impl
   "Do not call this directly; use 'with-gen-spec'."
   [extract-f extract-f|form gen-spec gen-spec|form]
   (if (fn? gen-spec)
       (let [form      `(with-gen-spec ~extract-f|form ~gen-spec|form)
-            gen-spec' (fn [x] (let [spec (gen-spec x)
-                                    desc (s/describe spec)
-                                    desc (if (= desc ::s/unknown)
-                                             (list 'some-generated-spec gen-spec|form)
-                                             desc)]
-                                (with extract-f (@#'s/spec-impl desc spec nil nil))))]
+            gen-spec' (fn [x]
+                        (let [spec (gen-spec x)
+                              desc (s/describe spec)
+                              desc (if (= desc ::s/unknown)
+                                       (list 'some-generated-spec gen-spec|form)
+                                       desc)]
+                          (s/nonconforming (s/and (s/conformer extract-f)
+                                                  (@#'s/spec-impl desc spec nil nil)))))]
         (reify
           s/Specize
             (s/specize*  [this] this)

--- a/src/quantum/untyped/core/test.cljc
+++ b/src/quantum/untyped/core/test.cljc
@@ -1,0 +1,34 @@
+(ns quantum.untyped.core.test
+  (:require
+    [clojure.spec.alpha      :as s]
+    [clojure.spec.test.alpha :as stest]
+    [clojure.string          :as str]
+    [clojure.test            :as test]))
+
+(defn report-results [check-results]
+  (let [checks-passed? (->> check-results (map :failure) (every? nil?))]
+    (if checks-passed?
+        (test/do-report {:type    :pass
+                         :message (str "Generative tests pass for "
+                                    (str/join ", " (map :sym check-results)))})
+        (doseq [failed-check (filter :failure check-results)]
+          (let [r       (stest/abbrev-result failed-check)
+                failure (:failure r)]
+            (test/do-report
+              {:type     :fail
+               :message  (with-out-str (s/explain-out failure))
+               :expected (->> r :spec rest (apply hash-map) :ret)
+               :actual   (if (instance? #?(:clj Throwable :cljs js/Error) failure)
+                             failure
+                             (::stest/val failure))}))))
+    checks-passed?))
+
+#?(:clj
+(defmacro defspec-test
+  {:based-on "https://gist.github.com/kennyjwilli/8bf30478b8a2762d2d09baabc17e2f10"}
+  ([name sym-or-syms] `(defspec-test ~name ~sym-or-syms nil))
+  ([name sym-or-syms opts]
+   (when test/*load-tests*
+     `(defn ~(vary-meta name assoc :test
+              `(fn [] (report-results (stest/check ~sym-or-syms ~opts))))
+        [] (test/test-var (var ~name)))))))

--- a/src/quantum/untyped/core/type/predicates.cljc
+++ b/src/quantum/untyped/core/type/predicates.cljc
@@ -1,24 +1,39 @@
 (ns quantum.untyped.core.type.predicates
   (:refer-clojure :exclude
-    [any? boolean? ident? qualified-keyword? simple-symbol?]))
+    [any? boolean? ident? qualified-keyword? simple-symbol?])
+  (:require
+    [clojure.core   :as core]
+#?(:clj
+    [clojure.future :as fcore])
+    [quantum.untyped.core.vars
+      :refer [defalias]]))
 
-(defn any?
-  "Returns true given any argument."
-  [x] true)
+;; The reason we use `resolve` and `eval` here is that currently we need to prefer built-in impls
+;; where possible in order to leverage their generators
 
-(defn boolean? [x] #?(:clj  (instance? Boolean x)
-                      :cljs (or (true? x) (false? x))))
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/any?)
+                               `fcore/any?
+                               `core/any?)))
+   :cljs (defalias core/any?))
 
-(defn ident?
-  "Return true if x is a symbol or keyword"
-  [x] (or (keyword? x) (symbol? x)))
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/boolean?)
+                               `fcore/boolean?
+                               `core/boolean?)))
+   :cljs (defalias core/boolean?))
 
-(defn qualified-keyword?
-  "Return true if x is a keyword with a namespace"
-  [x] (boolean (and (keyword? x) (namespace x) true)))
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/ident?)
+                               `fcore/ident?
+                               `core/ident?)))
+   :cljs (defalias core/ident?))
 
-(defn simple-symbol?
-  "Return true if x is a symbol without a namespace"
-  [x] (and (symbol? x) (nil? (namespace x))))
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/qualified-keyword?)
+                               `fcore/qualified-keyword?
+                               `core/qualified-keyword?)))
+   :cljs (defalias core/qualified-keyword?))
+
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/simple-symbol?)
+                               `fcore/simple-symbol?
+                               `core/simple-symbol?)))
+   :cljs (defalias core/simple-symbol?))
 
 (def val? some?)

--- a/src/quantum/untyped/core/type/predicates.cljc
+++ b/src/quantum/untyped/core/type/predicates.cljc
@@ -1,6 +1,6 @@
 (ns quantum.untyped.core.type.predicates
   (:refer-clojure :exclude
-    [any? boolean? ident? qualified-keyword? simple-symbol?])
+    [any? boolean? double? ident? pos-int? qualified-keyword? simple-symbol?])
   (:require
     [clojure.core   :as core]
 #?(:clj
@@ -21,10 +21,20 @@
                                `core/boolean?)))
    :cljs (defalias core/boolean?))
 
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/double?)
+                               `fcore/double?
+                               `core/double?)))
+   :cljs (defalias core/double?))
+
 #?(:clj  (eval `(defalias ~(if (resolve `fcore/ident?)
                                `fcore/ident?
                                `core/ident?)))
    :cljs (defalias core/ident?))
+
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/pos-int?)
+                               `fcore/pos-int?
+                               `core/pos-int?)))
+   :cljs (defalias core/pos-int?))
 
 #?(:clj  (eval `(defalias ~(if (resolve `fcore/qualified-keyword?)
                                `fcore/qualified-keyword?

--- a/src/quantum/untyped/core/vars.cljc
+++ b/src/quantum/untyped/core/vars.cljc
@@ -1,0 +1,34 @@
+(ns quantum.untyped.core.vars
+  (:require
+    [quantum.untyped.core.form.evaluate
+      :refer [case-env]]))
+
+#?(:clj
+(defn defalias* [^clojure.lang.Var orig-var ns-name- var-name]
+  (let [;; to avoid warnings
+        var-name' (with-meta var-name (-> orig-var meta (select-keys [:dynamic])))
+        ^clojure.lang.Var var-
+          (if (.hasRoot orig-var)
+              (intern ns-name- var-name' @orig-var)
+              (intern ns-name- var-name'))]
+    ;; because this doesn't always get set correctly
+    (cond-> var-
+      (.isDynamic orig-var)
+      (doto (.setDynamic))))))
+
+#?(:clj
+(defmacro defalias
+  "Defines an alias for a var: a new var with the same root binding (if
+  any) and similar metadata. The metadata of the alias is its initial
+  metadata (as provided by def) merged into the metadata of the original."
+  {:attribution  'clojure.contrib.def/defalias
+   :contributors ["Alex Gunnarson"]}
+  ([orig]
+    `(defalias ~(symbol (name orig)) ~orig))
+  ([name orig]
+    `(doto ~(case-env
+               :clj  `(defalias* (var ~orig) '~(ns-name *ns*) '~name)
+               :cljs `(def ~name (-> ~orig var deref)))
+            (alter-meta! merge (meta (var ~orig)))))
+  ([name orig doc]
+     (list `defalias (with-meta name (assoc (meta name) :doc doc)) orig))))

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -1,0 +1,136 @@
+(ns quantum.test.untyped.core.defnt
+  (:require
+    [clojure.spec.alpha         :as s]
+    [clojure.spec.gen.alpha     :as gen]
+    [quantum.untyped.core.defnt :as this]
+    [quantum.untyped.core.spec  :as us]))
+
+;; Implicit compilation test
+(this/defns fghijk "Documentation" {:metadata "abc"}
+  ([a number? > number?] (inc a))
+  ([a pos-int?, b pos-int?
+    | (> a b)
+    > (s/and number? #(> % a) #(> % b))] (+ a b))
+  ([a #{"a" "b" "c"}
+    b boolean?
+    {:as   c
+     :keys [ca keyword? cb string?]
+     {:as cc
+      {:as   cca
+       :keys [ccaa keyword?]
+       [[ccabaa some? {:as ccabab :keys [ccababa some?]} some?] some? ccabb some? & ccabc some? :as ccab]
+       [:ccab seq?]}
+      [:cca map?]}
+     [:cc map?]}
+    #(-> % count (= 3))
+    [da double? & db seq? :as d] sequential?
+    [ea symbol?] ^:gen? (s/coll-of symbol? :kind vector?)
+    & [fa #{"a" "b" "c"} :as f] seq?
+    | (and (> da 50) (contains? c a)
+           a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa)
+    > number?] 0))
+
+
+
+;; TODO assert that the below 2 things are equivalent
+
+#_(this/defns fghijk "Documentation" {:metadata "abc"}
+  ([a number? > number?] (inc a))
+  ([a pos-int?, b pos-int?
+    | (> a b)
+    > (s/and number? #(> % a) #(> % b))] (+ a b))
+  ([a #{"a" "b" "c"}
+    b boolean?
+    {:as   c
+     :keys [ca keyword? cb string?]
+     {:as cc
+      {:as   cca
+       :keys [ccaa keyword?]
+       [[ccabaa some? {:as ccabab :keys [ccababa some?]} some?] some? ccabb some? & ccabc some? :as ccab]
+       [:ccab seq?]}
+      [:cca map?]}
+     [:cc map?]}
+    #(-> % count (= 3))
+    [da double? & db seq? :as d] sequential?
+    [ea symbol?] ^:gen? (s/coll-of symbol? :kind vector?)
+    & [fa #{"a" "b" "c"} :as f] seq?
+    | (and (> da 50) (contains? c a)
+           a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa)
+    > number?] 0))
+
+#_(s/fdef fghijk
+  :args
+    (s/or
+      :arity-1 (s/cat :a number?)
+      :arity-2 (s/and (s/cat :a pos-int?
+                             :b pos-int?)
+                      (fn [{a :a b :b}] (> a b)))
+      :arity-varargs
+        (s/and
+          (s/cat
+            :a      #{"a" "b" "c"}
+            :b      boolean?
+            :c      (this/map-destructure #(-> % count (= 3))
+                      {:ca keyword?
+                       :cb string?
+                       :cc (this/map-destructure map?
+                             {:cca (this/map-destructure map?
+                                     {:ccaa keyword?
+                                      :ccab (this/seq-destructure seq?
+                                              [:arg-0 (this/seq-destructure some?
+                                                        [:ccabaa some?
+                                                         :ccabab (this/map-destructure some? {:ccababa some?})])
+                                               :ccabb some?]
+                                              [:ccabc some?])})})})
+            :d      (this/seq-destructure sequential? [:da double?] [:db seq?])
+            :arg-4# (this/seq-destructure ^{:gen? true} (s/coll-of symbol? :kind vector?) [:ea symbol?] )
+            :f      (this/seq-destructure seq? [:fa #{"a" "b" "c"}]))
+          (fn [{a :a
+                b :b
+                {:as c
+                 :keys [ca cb]
+                 {:as cc
+                  {:as cca
+                   :keys [ccaa]
+                   [[ccabaa {:as ccabab :keys [ccababa]}] ccabb & ccabc :as ccab] :ccab} :cca} :cc} :c
+                [da & db :as d] :d
+                [ea] :arg-4#
+                [fa :as f] :f :as X}]
+            (and (> da 50) (= a fa)
+                 a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa))))
+   :fn
+     (us/with-gen-spec (fn [{ret# :ret}] ret#)
+       (fn [{[arity-kind# args#] :args}]
+         (case arity-kind#
+           :arity-1
+             (let [{a :a} args#] (s/spec number?))
+           :arity-2
+             (let [{a :a b :b} args#] (s/spec (s/and number? #(> % a) #(> % b))))
+           :arity-varargs
+             (let [{a :a
+                    b :b
+                    {:as c
+                     :keys [ca cb]
+                     {:as cc
+                      {:as cca
+                       :keys [ccaa]
+                       [[ccabaa {:as ccabab :keys [ccababa]}] ccabb & ccabc :as ccab] :ccab} :cca} :cc} :c
+                    [da & db :as d] :d
+                    [ea] :arg-4#
+                    [fa :as f] :f} args#] (s/spec number?))))))
+
+#_(defn fghijk "Documentation" {:metadata "abc"}
+  ([a] (inc a))
+  ([a b] (+ a b))
+  ([a b
+    {:as c,
+     :keys [ca cb],
+     {:as cc,
+      {:as cca,
+       :keys [ccaa],
+       [[ccabaa {:as ccabab, :keys [ccababa]}] ccabb & ccabc :as ccab] :ccab} :cca} :cc}
+    [da & db :as d]
+    [ea]
+    &
+    [fa :as f]]
+   0))

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -1,4 +1,6 @@
 (ns quantum.test.untyped.core.defnt
+  (:refer-clojure :exclude
+    [boolean? double? pos-int?])
   (:require
     [clojure.spec.alpha         :as s]
     [clojure.spec.gen.alpha     :as gen]
@@ -8,7 +10,9 @@
     [quantum.untyped.core.defnt :as this]
     [quantum.untyped.core.spec  :as us]
     [quantum.untyped.core.test
-      :refer [defspec-test]]))
+      :refer [defspec-test]]
+    [quantum.untyped.core.type.predicates
+      :refer [boolean? double? pos-int?]]))
 
 ;; Implicit compilation tests
 (this/defns fghijk "Documentation" {:metadata "abc"}

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -37,15 +37,24 @@
 
 (this/defns basic [a number? > number?] (rand))
 
-(defspec-test basic-test `basic)
+(defspec-test test|basic `basic)
 
 (this/defns equality [a number? > #(= % a)] a)
 
-(defspec-test equality-test `equality)
+(defspec-test test|equality `equality)
 
 (this/defns pre-post [a number? | (> a 3) > #(> % 4)] (inc a))
 
-(defspec-test pre-post-test `pre-post)
+(defspec-test test|pre-post `pre-post)
+
+(this/defns gen|seq|0 [[a number? b number? :as b] ^:gen? (s/tuple double? double?)])
+
+(defspec-test test|gen|seq|0 `gen|seq|0)
+
+(this/defns gen|seq|1
+  [[a number? b number? :as b] ^:gen? (s/nonconforming (s/cat :a double? :b double?))])
+
+(defspec-test test|gen|seq|1 `gen|seq|1)
 
 ;; TODO assert that the below 2 things are equivalent
 

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -2,10 +2,15 @@
   (:require
     [clojure.spec.alpha         :as s]
     [clojure.spec.gen.alpha     :as gen]
+    [clojure.spec.test.alpha    :as stest]
+    [clojure.test.check.clojure-test
+      :refer [defspec]]
     [quantum.untyped.core.defnt :as this]
-    [quantum.untyped.core.spec  :as us]))
+    [quantum.untyped.core.spec  :as us]
+    [quantum.untyped.core.test
+      :refer [defspec-test]]))
 
-;; Implicit compilation test
+;; Implicit compilation tests
 (this/defns fghijk "Documentation" {:metadata "abc"}
   ([a number? > number?] (inc a))
   ([a pos-int?, b pos-int?
@@ -30,7 +35,17 @@
            a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa)
     > number?] 0))
 
+(this/defns basic [a number? > number?] (rand))
 
+(defspec-test basic-test `basic)
+
+(this/defns equality [a number? > #(= % a)] a)
+
+(defspec-test equality-test `equality)
+
+(this/defns pre-post [a number? | (> a 3) > #(> % 4)] (inc a))
+
+(defspec-test pre-post-test `pre-post)
 
 ;; TODO assert that the below 2 things are equivalent
 


### PR DESCRIPTION
This resolves the only known bug (really, a feature-lack) in 0.1.0 — the lack of out-of-the-box generative testing ability for `defns`es.