### PR TITLE
0.2.1: Fix underscore specs in seq and map destructuring contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,4 +20,4 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "project.clj" }}
-      - run: lein with-profile clj-1.8 test && lein with-profile clj-1.9 test
+      - run: lein with-profile clj-1.8.0 test && lein with-profile clj-1.9.0 test

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .DS_Store
+*.pom

--- a/project.clj
+++ b/project.clj
@@ -1,31 +1,104 @@
-(def deps|clj-1-8
+(require
+  'leiningen.deploy
+  'leiningen.jar
+  'leiningen.pom)
+
+(def deps|clj-1-8-0
  '[[clojure-future-spec    "1.9.0-beta4"]
    [frankiesardo/linked    "1.2.9"]
-   [org.clojure/clojure    "1.8.0"]])
+   [org.clojure/clojure    "1.8.0"]
+   [org.clojure/test.check "0.9.0"]])
 
-(def deps|clj-1-9
+(def deps|clj-1-9-0
  '[[clojure-future-spec    "1.9.0-beta4"]
    [frankiesardo/linked    "1.2.9"]
    [org.clojure/clojure    "1.9.0"]
-   [org.clojure/spec.alpha "0.1.143"]])
+   [org.clojure/spec.alpha "0.1.143"]
+   [org.clojure/test.check "0.9.0"]])
 
-(defproject quantum/defnt "0.2.0"
-  :description  "Where `defn` meets `clojure.spec` and a gradual-typing baby is born."
-  :url          "https://github.com/alexandergunnarson/defnt"
-  :license      {:name         "Creative Commons Attribution-ShareAlike 3.0 US (CC-SA)"
-                 :url          "https://creativecommons.org/licenses/by-sa/3.0/us/"
-                 :distribution :repo}
-  :profiles
-    {:dev||test {:global-vars {*warn-on-reflection* true
-                               *unchecked-math*     :warn-on-boxed}}
-     :dev       [:dev||test
-                 {:dependencies ~(conj deps|clj-1-9
+(def project-name 'quantum/defnt)
+(def version "0.2.0")
+
+(defn >base-profile [profile-ident #_keyword?]
+  (let [relativized-version
+          (if (= profile-ident :current)
+              version
+              (str version "-" (name profile-ident)))]
+    {:version      relativized-version
+     :jar-name     (str "defnt" "-" relativized-version ".jar")
+     :uberjar-name (str "defnt" "-" relativized-version "-uberjar.jar")
+     :pom-name     (str "defnt" "-" relativized-version ".pom")}))
+
+(def profiles
+  (let [dev||test {:global-vars '{*warn-on-reflection* true
+                                  *unchecked-math*     :warn-on-boxed}}]
+    {:dev||test dev||test
+     :dev       (merge dev||test
+                  {:dependencies (conj deps|clj-1-9-0
                                    '[expound                "0.6.0"]
                                    '[orchestra              "2017.11.12-1"]
-                                   '[org.clojure/test.check "0.9.0"])}]
-     :test      [:dev||test]
-     :clj-1-8   {:dependencies ~(conj deps|clj-1-8
-                                  '[org.clojure/test.check "0.9.0"])}
-     :clj-1-9   {:dependencies ~(conj deps|clj-1-9
-                                  '[org.clojure/test.check "0.9.0"])}})
+                                   '[leiningen              "2.8.0"])})
+     :test      (merge dev||test)
+     :clj-1.8.0 (-> (>base-profile :clj-1.8.0)
+                    (assoc :dependencies deps|clj-1-8-0))
+     :clj-1.9.0 (-> (>base-profile :clj-1.9.0)
+                    (assoc :dependencies deps|clj-1-9-0))
+     :current   (-> (>base-profile :current)
+                    (assoc :dependencies deps|clj-1-9-0))}))
 
+(def config
+  {:name        project-name
+   :version     version
+   :description "Where `defn` meets `clojure.spec` and a gradual-typing baby is born."
+   :url         "https://github.com/alexandergunnarson/defnt"
+   :license     {:name         "Creative Commons Attribution-ShareAlike 3.0 US (CC-SA)"
+                 :url          "https://creativecommons.org/licenses/by-sa/3.0/us/"
+                 :distribution :repo}
+   :deploy-repositories
+     {"clojars" {:url "https://repo.clojars.org" :username :gpg :password :gpg}}
+   :profiles    profiles})
+
+(def the-project
+  (leiningen.core.project/make config
+    project-name version (some-> (clojure.java.io/file *file*) (.getParent))))
+
+;; ===== Commands ===== ;;
+
+(defn >profiled-project [profile-ident]
+  (-> the-project
+      (merge (get profiles profile-ident))
+      ;; To prevent e.g.:
+      ;; `[clojure-future-spec "1.9.0-beta4"]` and
+      ;; `[clojure-future-spec/clojure-future-spec "1.9.0-beta4" :scope "test"]`
+      (dissoc :profiles)
+      leiningen.core.project/init-project))
+
+(defn write-jar! [profile-ident #_keyword?]
+  (clojure.java.shell/sh "rm" "-rf" "./target")
+  (leiningen.jar/jar (>profiled-project profile-ident)))
+
+(defn write-pom! [profile-ident #_keyword?]
+  (leiningen.pom/pom (>profiled-project profile-ident)
+    (get-in profiles [profile-ident :pom-name])))
+
+(defn deploy! [profile-ident #_keyword?]
+  (write-jar! profile-ident)
+  (write-pom! profile-ident)
+  (leiningen.deploy/deploy
+    (>profiled-project profile-ident)
+    "clojars"
+    (str project-name)
+    (get-in profiles [profile-ident :version])
+    (str "./target/" (get-in profiles [profile-ident :jar-name]))
+    (str "./"        (get-in profiles [profile-ident :pom-name]))))
+
+;; A more flexible `:aliases`
+;; E.g. LEIN_COMMAND="deploy-all" lein
+(when-let [command (System/getenv "LEIN_COMMAND")]
+  (case command
+    "deploy-all" (do #_(deploy! :clj-1.8.0)
+                     (deploy! :clj-1.9.0)
+                     (deploy! :current))
+    (throw (ex-info "Unhandled command" {:command command}))))
+
+(def project the-project)

--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
 ;; E.g. LEIN_COMMAND="deploy-all" lein
 (when-let [command (System/getenv "LEIN_COMMAND")]
   (case command
-    "deploy-all" (do #_(deploy! :clj-1.8.0)
+    "deploy-all" (do (deploy! :clj-1.8.0)
                      (deploy! :clj-1.9.0)
                      (deploy! :current))
     (throw (ex-info "Unhandled command" {:command command}))))

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
    [org.clojure/test.check "0.9.0"]])
 
 (def project-name 'quantum/defnt)
-(def version "0.2.0")
+(def version "0.2.1")
 
 (defn >base-profile [profile-ident #_keyword?]
   (let [relativized-version

--- a/src/quantum/untyped/core/defnt.cljc
+++ b/src/quantum/untyped/core/defnt.cljc
@@ -1,6 +1,6 @@
 (ns quantum.untyped.core.defnt
   "Primarily for `(de)fns`."
-  (:refer-clojure :exclude [any? ident? qualified-keyword? simple-symbol?])
+  (:refer-clojure :exclude [any? ident? qualified-keyword? seqable? simple-symbol?])
   (:require
     [clojure.spec.alpha                 :as s]
     [clojure.spec.gen.alpha             :as gen]
@@ -14,7 +14,7 @@
     [quantum.untyped.core.spec          :as us]
     [quantum.untyped.core.specs]
     [quantum.untyped.core.type.predicates
-      :refer [any? ident? qualified-keyword? simple-symbol?]]))
+      :refer [any? ident? qualified-keyword? seqable? simple-symbol?]]))
 
 ;; ===== Specs ===== ;;
 
@@ -269,7 +269,7 @@
 
 (defn- speced-binding|seq>spec
   [{:as speced-binding [kind binding-] :binding-form [spec-kind spec] :spec}]
-  `(seq-destructure ~spec
+  `(seq-destructure ~(if (= spec-kind :spec) spec `seqable?)
     ~(->> binding- :elems
           (map-indexed
             (fn [i|arg arg|speced-binding]
@@ -291,7 +291,7 @@
 
 (defn- speced-binding|map>spec
   [{:as speced-binding [kind binding-] :binding-form [spec-kind spec] :spec}]
-  `(map-destructure ~spec
+  `(map-destructure ~(if (= spec-kind :spec) spec `map?)
     ~(->> (dissoc binding- :as :or)
           (map (fn [[k v]]
                  (case k

--- a/src/quantum/untyped/core/type/predicates.cljc
+++ b/src/quantum/untyped/core/type/predicates.cljc
@@ -1,6 +1,6 @@
 (ns quantum.untyped.core.type.predicates
   (:refer-clojure :exclude
-    [any? boolean? double? ident? pos-int? qualified-keyword? simple-symbol?])
+    [any? boolean? double? ident? pos-int? qualified-keyword? seqable? simple-symbol?])
   (:require
     [clojure.core   :as core]
 #?(:clj
@@ -40,6 +40,11 @@
                                `fcore/qualified-keyword?
                                `core/qualified-keyword?)))
    :cljs (defalias core/qualified-keyword?))
+
+#?(:clj  (eval `(defalias ~(if (resolve `fcore/seqable?)
+                               `fcore/seqable?
+                               `core/seqable?)))
+   :cljs (defalias core/seqable?))
 
 #?(:clj  (eval `(defalias ~(if (resolve `fcore/simple-symbol?)
                                `fcore/simple-symbol?

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -39,26 +39,31 @@
            a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa)
     > number?] 0))
 
-(this/defns basic [a number? > number?] (rand))
+#?(:clj
+(defmacro defns-test [sym & args]
+  `(do (this/defns ~sym ~@args)
+       (defspec-test ~(symbol (str "test|" sym)) (symbol (str (ns-name *ns*)) ~(str sym))))))
 
-(defspec-test test|basic `basic)
+(defns-test basic [a number? > number?] (rand))
 
-(this/defns equality [a number? > #(= % a)] a)
+(defns-test equality [a number? > #(= % a)] a)
 
-(defspec-test test|equality `equality)
+(defns-test pre-post [a number? | (> a 3) > #(> % 4)] (inc a))
 
-(this/defns pre-post [a number? | (> a 3) > #(> % 4)] (inc a))
+(defns-test gen|seq|0 [[a number? b number? :as b] ^:gen? (s/tuple double? double?)])
 
-(defspec-test test|pre-post `pre-post)
-
-(this/defns gen|seq|0 [[a number? b number? :as b] ^:gen? (s/tuple double? double?)])
-
-(defspec-test test|gen|seq|0 `gen|seq|0)
-
-(this/defns gen|seq|1
+(defns-test gen|seq|1
   [[a number? b number? :as b] ^:gen? (s/nonconforming (s/cat :a double? :b double?))])
 
-(defspec-test test|gen|seq|1 `gen|seq|1)
+(defns-test underscore-binding [a number? _ string?] a)
+
+(defns-test underscore-spec|sym [a _ b string?] a)
+
+(defns-test underscore-spec|seq [[a string?] _ b string?] a)
+
+(defns-test underscore-spec|map [{:keys [a string?]} _ b string?] a)
+
+(defns-test underscore-binding+spec [a _ _ #{""} > #{""}] _)
 
 ;; TODO assert that the below 2 things are equivalent
 

--- a/test/quantum/test/untyped/core/defnt.cljc
+++ b/test/quantum/test/untyped/core/defnt.cljc
@@ -15,7 +15,7 @@
       :refer [boolean? double? pos-int?]]))
 
 ;; Implicit compilation tests
-(this/defns fghijk "Documentation" {:metadata "abc"}
+(this/defns abcde "Documentation" {:metadata "abc"}
   ([a number? > number?] (inc a))
   ([a pos-int?, b pos-int?
     | (> a b)
@@ -62,7 +62,7 @@
 
 ;; TODO assert that the below 2 things are equivalent
 
-#_(this/defns fghijk "Documentation" {:metadata "abc"}
+#_(this/defns abcde "Documentation" {:metadata "fhgjik"}
   ([a number? > number?] (inc a))
   ([a pos-int?, b pos-int?
     | (> a b)
@@ -86,7 +86,7 @@
            a b c ca cb cc cca ccaa ccab ccabaa ccabab ccababa ccabb ccabc d da db ea f fa)
     > number?] 0))
 
-#_(s/fdef fghijk
+#_(s/fdef abcde
   :args
     (s/or
       :arity-1 (s/cat :a number?)
@@ -147,7 +147,7 @@
                     [ea] :arg-4#
                     [fa :as f] :f} args#] (s/spec number?))))))
 
-#_(defn fghijk "Documentation" {:metadata "abc"}
+#_(defn abcde "Documentation" {:metadata "abc"}
   ([a] (inc a))
   ([a b] (+ a b))
   ([a b


### PR DESCRIPTION
Previously these wouldn't compile but now they do:

```clojure
(defns abcde [[a string?] _ b string?] a)
(defns ghijk [{:keys [a string?]} _ b string?] a)
```